### PR TITLE
Slideshow paging

### DIFF
--- a/app/src/main/java/com/manwinder/nbcuniversalkotlin/ui/MainActivity.kt
+++ b/app/src/main/java/com/manwinder/nbcuniversalkotlin/ui/MainActivity.kt
@@ -45,15 +45,21 @@ class MainActivity : AppCompatActivity() {
         news_feed.adapter = newsFeedAdapter
         news_feed.addItemDecoration(DividerItemDecoration(news_feed.context, DividerItemDecoration.VERTICAL))
 
-        swipe_refresh_layout.isRefreshing = true
+        if (supportFragmentManager.backStackEntryCount == 0) {
+            swipe_refresh_layout.isRefreshing = true
+        }
         fab.hide()
 
         val newsItemObserver = Observer<Resource<List<NewsItem>?>> { resource->
             when(resource?.status) {
                 Status.SUCCESS -> {
-                    changeSnackbarText("News updated")
-                    swipe_refresh_layout.isRefreshing = false
-                    fab.show()
+
+                    // keeps refresh circle and fab hidden in fragments, this will run in fragments on orientation change
+                    if (supportFragmentManager.backStackEntryCount == 0) {
+                        swipe_refresh_layout.isRefreshing = false
+                        changeSnackbarText("News updated")
+                        fab.show()
+                    }
 
                     resource.data?.let { newsItemList ->
                         newsItemsList.addAll(newsItemList)
@@ -88,13 +94,14 @@ class MainActivity : AppCompatActivity() {
         // Shows/hides the fab on scroll
         news_feed.addOnScrollListener(object: RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
-                if (dy > 0 || dy < 0 && fab.isShown) {
+                if (dy > 0 || dy < 0 && fab.isShown && supportFragmentManager.backStackEntryCount == 0) {
                     fab.hide()
                 }
             }
 
             override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
-                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+
+                if (newState == RecyclerView.SCROLL_STATE_IDLE && supportFragmentManager.backStackEntryCount == 0) {
                     fab.show()
                 }
                 super.onScrollStateChanged(recyclerView, newState)

--- a/app/src/main/java/com/manwinder/nbcuniversalkotlin/ui/SlideShowFragment.kt
+++ b/app/src/main/java/com/manwinder/nbcuniversalkotlin/ui/SlideShowFragment.kt
@@ -2,8 +2,7 @@ package com.manwinder.nbcuniversalkotlin.ui
 
 import android.os.Bundle
 import android.support.v4.app.Fragment
-import android.support.v7.widget.DividerItemDecoration
-import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.*
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -34,5 +33,8 @@ class SlideShowFragment : Fragment() {
         slide_show.layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
         val slideShowAdapter = SlideShowAdapter(slideShowList)
         slide_show.adapter = slideShowAdapter
+
+        val helper = PagerSnapHelper()
+        helper.attachToRecyclerView(slide_show)
     }
 }

--- a/app/src/main/java/com/manwinder/nbcuniversalkotlin/ui/VideoFragment.kt
+++ b/app/src/main/java/com/manwinder/nbcuniversalkotlin/ui/VideoFragment.kt
@@ -31,16 +31,26 @@ class VideoFragment : Fragment() {
             loading_bar_video.show()
         }
 
-        loadVideo()
+        savedInstanceState?.let {
+            loadVideo(savedInstanceState.getLong("time"))
+        } ?: run {
+            loadVideo()
+        }
     }
 
-    private fun loadVideo() {
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putLong("time", video.currentPosition)
+        super.onSaveInstanceState(outState)
+    }
+
+    private fun loadVideo(time : Long = 0) {
         arguments?.let {
             val url = it.getString("URL")
 
             video.setOnPreparedListener {
-                video.start()
                 loading_bar_video.hide()
+                video.seekTo(time)
+                video.start()
             }
 
             Fuel.download(url).destination { _, _ ->
@@ -49,6 +59,7 @@ class VideoFragment : Fragment() {
                 val str = String(result.get(), Charset.defaultCharset())
                 val arr = str.split("\n")
                 video.setVideoURI(Uri.parse(arr[arr.size - 2]))
+//                video.setPositionOffset(time)
             }
         }
     }


### PR DESCRIPTION
# Description

- Updated `SlideShowFragment` RecyclerView to snap when scrolling
- Fab and snackbar don't show up in fragments anymore, this usually happened on orientation change
- Video in `VideoFragment` now will continue to play from the same position on a orientation change rather than beginning from the start

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes