### PR TITLE
Changed video player from devbracket's exomedia to Google's exoplayer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,9 +33,9 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'com.android.support:appcompat-v7:28.0.0-alpha3'
-    implementation 'com.android.support:recyclerview-v7:28.0.0-alpha3'
-    implementation 'com.android.support:design:28.0.0-alpha3'
+    implementation 'com.android.support:appcompat-v7:28.0.0-beta01'
+    implementation 'com.android.support:recyclerview-v7:28.0.0-beta01'
+    implementation 'com.android.support:design:28.0.0-beta01'
 
     implementation 'android.arch.lifecycle:extensions:1.1.1'
 
@@ -54,15 +54,14 @@ dependencies {
     kapt "android.arch.persistence.room:compiler:1.1.1"
 
     // LiveData + ViewModel
-
     implementation "android.arch.lifecycle:extensions:1.1.1"
-
 
     implementation 'com.squareup.picasso:picasso:2.71828'
 
-    implementation 'com.devbrackets.android:exomedia:4.2.1'
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.8.2'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.8.2'
+    implementation 'com.google.android.exoplayer:exoplayer-hls:2.8.2'
 
-    implementation 'com.github.kittinunf.fuel:fuel:1.14.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.10.0'
 
     testImplementation 'junit:junit:4.12'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.manwinder.nbcuniversalkotlin">
 
-    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/manwinder/nbcuniversalkotlin/ui/MainActivity.kt
+++ b/app/src/main/java/com/manwinder/nbcuniversalkotlin/ui/MainActivity.kt
@@ -47,13 +47,14 @@ class MainActivity : AppCompatActivity() {
 
         if (supportFragmentManager.backStackEntryCount == 0) {
             swipe_refresh_layout.isRefreshing = true
+        } else {
+            supportActionBar?.hide()
         }
         fab.hide()
 
         val newsItemObserver = Observer<Resource<List<NewsItem>?>> { resource->
             when(resource?.status) {
                 Status.SUCCESS -> {
-
                     // keeps refresh circle and fab hidden in fragments, this will run in fragments on orientation change
                     if (supportFragmentManager.backStackEntryCount == 0) {
                         swipe_refresh_layout.isRefreshing = false
@@ -112,6 +113,7 @@ class MainActivity : AppCompatActivity() {
     private fun newsItemClick(newsItem : NewsItem) {
         val args = Bundle()
         fab.hide()
+        supportActionBar?.hide()
         when {
             newsItem.type == "video" -> {
                 args.putString("URL", newsItem.videoUrl)
@@ -139,6 +141,11 @@ class MainActivity : AppCompatActivity() {
 
     override fun onBackPressed() {
         if (supportFragmentManager.backStackEntryCount != 0) {
+            supportActionBar?.let {
+                if (!it.isShowing) {
+                    it.show()
+                }
+            }
             supportFragmentManager.popBackStack()
             fab.show()
         } else {

--- a/app/src/main/java/com/manwinder/nbcuniversalkotlin/ui/VideoFragment.kt
+++ b/app/src/main/java/com/manwinder/nbcuniversalkotlin/ui/VideoFragment.kt
@@ -6,14 +6,25 @@ import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.github.kittinunf.fuel.Fuel
+import com.google.android.exoplayer2.ExoPlayer
+import com.google.android.exoplayer2.ExoPlayerFactory
+import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.Player.STATE_BUFFERING
+import com.google.android.exoplayer2.Player.STATE_READY
+import com.google.android.exoplayer2.source.hls.HlsMediaSource
+import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
+import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory
+import com.google.android.exoplayer2.util.Util
 import com.manwinder.nbcuniversalkotlin.R
 import kotlinx.android.synthetic.main.video_fragment.*
-import java.io.File
-import java.nio.charset.Charset
 
 
 class VideoFragment : Fragment() {
+
+    private lateinit var player : ExoPlayer
 
     companion object {
         fun newInstance() = VideoFragment()
@@ -38,29 +49,60 @@ class VideoFragment : Fragment() {
         }
     }
 
+    override fun onPause() {
+        player.release()
+        super.onPause()
+    }
+
+    override fun onStop() {
+        player.release()
+        super.onStop()
+    }
+
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putLong("time", video.currentPosition)
+        outState.putLong("time", player.currentPosition)
         super.onSaveInstanceState(outState)
     }
+
 
     private fun loadVideo(time : Long = 0) {
         arguments?.let {
             val url = it.getString("URL")
 
-            video.setOnPreparedListener {
-                loading_bar_video.hide()
-                video.seekTo(time)
-                video.start()
-            }
+            // 1. Create a default TrackSelector
+            val bandwidthMeter = DefaultBandwidthMeter()
+            val videoTrackSelectionFactory = AdaptiveTrackSelection.Factory(bandwidthMeter)
+            val trackSelector = DefaultTrackSelector(videoTrackSelectionFactory)
 
-            Fuel.download(url).destination { _, _ ->
-                File.createTempFile("temp", ".tmp")
-            }.response { _, _, result ->
-                val str = String(result.get(), Charset.defaultCharset())
-                val arr = str.split("\n")
-                video.setVideoURI(Uri.parse(arr[arr.size - 2]))
-//                video.setPositionOffset(time)
+            // 2. Create the player
+            player = ExoPlayerFactory.newSimpleInstance(context, trackSelector)
+
+            video.player = player
+
+            // Produces DataSource instances through which media data is loaded.
+            val userAgent = Util.getUserAgent(context, "User Agent")
+            val dataSourceFactory = DefaultHttpDataSourceFactory(userAgent, null, DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS, 30000, true)
+
+            val videoSource = HlsMediaSource.Factory(dataSourceFactory)
+                    .setMinLoadableRetryCount(30000)
+                    .setAllowChunklessPreparation(true)
+                    .createMediaSource(Uri.parse(url))
+
+            val listener = object: Player.DefaultEventListener() {
+                override fun onPlayerStateChanged(playWhenReady: Boolean, playbackState: Int) {
+                    super.onPlayerStateChanged(playWhenReady, playbackState)
+                    when (playbackState) {
+                        STATE_READY -> {
+                            player.playWhenReady = true
+                            loading_bar_video.hide()
+                        }
+                        STATE_BUFFERING -> loading_bar_video.show()
+                    }
+                }
             }
+            player.addListener(listener)
+            player.prepare(videoSource)
+            player.seekTo(time)
         }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,6 +6,7 @@
     android:id="@+id/main_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:animateLayoutChanges="true"
     tools:context=".ui.MainActivity">
 
         <android.support.v4.widget.SwipeRefreshLayout

--- a/app/src/main/res/layout/article_fragment.xml
+++ b/app/src/main/res/layout/article_fragment.xml
@@ -15,8 +15,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        android:indeterminateTint="@color/colorPrimaryDark"
         style="?android:attr/progressBarStyleLarge"
-        android:visibility="invisible"
-        />
+        android:visibility="invisible" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/slide_show_item.xml
+++ b/app/src/main/res/layout/slide_show_item.xml
@@ -35,6 +35,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        android:indeterminateTint="@color/colorPrimaryDark"
         style="?android:attr/progressBarStyleLarge"/>
 
 </FrameLayout>

--- a/app/src/main/res/layout/video_fragment.xml
+++ b/app/src/main/res/layout/video_fragment.xml
@@ -2,20 +2,19 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@android:color/black">
 
-    <com.devbrackets.android.exomedia.ui.widget.VideoView
+    <com.google.android.exoplayer2.ui.PlayerView
         android:id="@+id/video"
-        android:layout_height="match_parent"
         android:layout_width="match_parent"
-        app:useDefaultControls="true"/>
+        android:layout_height="match_parent"/>
 
     <android.support.v4.widget.ContentLoadingProgressBar
         android:id="@+id/loading_bar_video"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        android:indeterminateTint="@color/colorPrimaryDark"
         style="?android:attr/progressBarStyleLarge"
         android:visibility="invisible"
         />

--- a/app/src/test/java/com/manwinder/nbcuniversalkotlin/api/NBCApiTest.kt
+++ b/app/src/test/java/com/manwinder/nbcuniversalkotlin/api/NBCApiTest.kt
@@ -68,8 +68,6 @@ class NBCApiTest {
         enqueueResponse("news_response.json")
 
         val newsItemsResponse = nbcApi.getNewsItems().blockingObserve()
-        println(newsItemsResponse)
-        println(newsItemsResponse?.status)
         assertThat(newsItemsResponse?.status, `is`(Status.SUCCESS))
 
         // without the timeout this request sometimes hangs

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.51'
+    ext.kotlin_version = '1.2.60'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0-alpha03'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha04'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0-alpha04"
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jul 19 21:48:20 EDT 2018
+#Sat Aug 04 18:00:04 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip


### PR DESCRIPTION
# Description

- switched from devbracket's exomedia library to google's exoplayer
- removed fuel library which was used to download the Master m3u8 playlist
- `DefaultHttpDataSourceFactory` is now used to retrieve the Master m3u8 playlist


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes